### PR TITLE
Implement Binance WebSocket broadcaster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shuttle-axum = "0.35"
 shuttle-runtime = "0.35"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "sync"] }
+tokio = { version = "1.37", features = ["full"] }
+tokio-tungstenite = "0.21"
+tungstenite = "0.21"
 tower-http = { version = "0.4", features = ["fs"] }
-reqwest = { version = "0.11", features = ["json"] }
-rig = "0.4"
-thiserror = "1.0"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # crypto-scanner-agent
 
-This example demonstrates a simple Axum based websocket server combined with a
-DeepSeek agent powered by the `rig` library. Incoming websocket messages are
-used as prompts for the agent. The server also broadcasts periodic status
-updates.
+This project is a minimal Axum application that streams cryptocurrency gainers over WebSocket.
+Incoming data is pulled from the Binance `!ticker@arr` feed and filtered server side before being broadcast
+to any connected clients.  A small example client is served from the `static` directory.

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,12 @@
+<ul id="feed"></ul>
+<script>
+ const ul = document.getElementById("feed");
+ const ws = new WebSocket("wss://" + location.host + "/websocket");
+ ws.onmessage = ev => {
+   const s = JSON.parse(ev.data);
+   const li = document.createElement("li");
+   li.textContent = `${s.symbol}: +${s.pct_gain_24h}%  vol $${(s.quote_vol_usdt/1e6).toFixed(1)}M`;
+   ul.prepend(li);
+   if (ul.children.length > 100) ul.lastChild.remove();
+ };
+</script>


### PR DESCRIPTION
## Summary
- turn the example into a crypto gainer broadcaster
- track Binance `!ticker@arr` stream and broadcast filtered results
- add basic client in `static/index.html`
- update README for new behaviour
- update dependencies

## Testing
- `cargo check` *(fails: failed to get crates)*