### PR TITLE
Add setup and run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,36 @@
 # crypto-scanner-agent
 
 This project is a minimal Axum application that streams cryptocurrency gainers over WebSocket.
-Incoming data is pulled from the Binance `!ticker@arr` feed and filtered server side before being broadcast
-to any connected clients.  A small example client is served from the `static` directory.
+Incoming data is pulled from the Binance `!ticker@arr` feed and filtered server side before being broadcast to any connected clients.
+A small example client is served from the `static` directory.
+
+## Prerequisites
+
+- Install [Rust](https://www.rust-lang.org/tools/install).
+- (Optional) Install the Shuttle CLI if you want to use Shuttle's local runner: `cargo install cargo-shuttle`.
+
+## API Keys
+
+The Binance stream used here is public, so **no API keys are required**. The application works out of the box without further configuration.
+
+## Running the Server
+
+1. Clone this repository and change into its directory:
+   ```bash
+   git clone <this-repo-url>
+   cd crypto-scanner-agent
+   ```
+2. Build and start the service with Cargo:
+   ```bash
+   cargo run --release
+   ```
+   By default the server listens on `127.0.0.1:8000`. It exposes a WebSocket endpoint at `/websocket` and serves a basic HTML client at the root path.
+3. Visit `http://localhost:8000/` in your browser to see the live feed. Each message shows a coin symbol and volume information whenever the 24h price increase exceeds 5% and the quote volume is above $1M.
+
+### Running with Shuttle
+
+If you have the Shuttle CLI installed, you can alternatively run
+```bash
+cargo shuttle run
+```
+which launches the application inside Shuttle's runtime. This mirrors how the service would run when deployed through Shuttle.


### PR DESCRIPTION
## Summary
- document Rust and Shuttle CLI requirements
- explain that no API keys are needed
- add step-by-step instructions for running the server

## Testing
- `cargo check` *(fails: could not download crates)*