### PR TITLE
Add canonical cargo commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,19 @@ Execute the unit tests with Cargo:
 cargo test
 ```
 
+## Canonical Cargo Commands
+
+The helper scripts above are optional. You can perform the same tasks using
+standard Cargo commands:
+
+```bash
+# start the server
+cargo run --release
+
+# run the sentiment example
+cargo run --bin sentiment --release
+
+# deploy with Shuttle
+cargo shuttle deploy -- --secrets backend/Secrets.toml
+```
+


### PR DESCRIPTION
## Summary
- document canonical Cargo commands in the README

## Testing
- `cargo fmt --all` *(fails: 'cargo-fmt' not installed)*
- `cargo check` *(fails to download crates)*
- `cargo test --no-run` *(fails to download crates)*