### PR TITLE
Add calculator example using DeepSeek

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ Execute the unit tests with Cargo:
 cargo test
 ```
 
+## Examples
+
+Two optional binaries demonstrate how to call DeepSeek outside of the
+crypto gainer service:
+
+- `sentiment` showcases running several extraction agents in parallel.
+- `calculator` illustrates using DeepSeek tools for simple arithmetic.
+
 ## Canonical Cargo Commands
 
 The helper scripts above are optional. You can perform the same tasks using
@@ -91,6 +99,10 @@ cargo run --release
 
 # run the sentiment example
 cargo run --bin sentiment --release
+
+
+# run the calculator example (optional)
+cargo run --bin calculator --release
 
 # deploy with Shuttle
 cargo shuttle deploy -- --secrets backend/Secrets.toml

--- a/src/bin/calculator.rs
+++ b/src/bin/calculator.rs
@@ -1,0 +1,133 @@
+//! Minimal example demonstrating DeepSeek tools for arithmetic operations.
+//!
+//! This binary is provided for demonstration purposes only and is not part of
+//! the main cryptocurrency gainer service.
+
+use rig::{
+    completion::{Prompt, ToolDefinition},
+    providers,
+    tool::Tool,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .init();
+
+    let client = providers::deepseek::Client::from_env();
+    let agent = client
+        .agent("deepseek-chat")
+        .preamble("You are a helpful assistant.")
+        .build();
+
+    let answer = agent.prompt("Tell me a joke").await?;
+    println!("Answer: {}", answer);
+
+    // Create agent with a single context prompt and two tools
+    let calculator_agent = client
+        .agent(providers::deepseek::DEEPSEEK_CHAT)
+        .preamble(
+            "You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question."
+        )
+        .max_tokens(1024)
+        .tool(Adder)
+        .tool(Subtract)
+        .build();
+
+    // Prompt the agent and print the response
+    println!("Calculate 2 - 5");
+    println!(
+        "DeepSeek Calculator Agent: {}",
+        calculator_agent.prompt("Calculate 2 - 5").await?
+    );
+
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct OperationArgs {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Math error")]
+struct MathError;
+
+#[derive(Deserialize, Serialize)]
+struct Adder;
+impl Tool for Adder {
+    const NAME: &'static str = "add";
+
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "add".to_string(),
+            description: "Add x and y together".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "description": "The first number to add"
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "The second number to add"
+                    }
+                }
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        println!("[tool-call] Adding {} and {}", args.x, args.y);
+        let result = args.x + args.y;
+        Ok(result)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct Subtract;
+impl Tool for Subtract {
+    const NAME: &'static str = "subtract";
+
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        serde_json::from_value(json!({
+            "name": "subtract",
+            "description": "Subtract y from x (i.e.: x - y)",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "description": "The number to subtract from"
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "The number to subtract"
+                    }
+                }
+            }
+        }))
+        .expect("Tool Definition")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        println!("[tool-call] Subtracting {} from {}", args.y, args.x);
+        let result = args.x - args.y;
+        Ok(result)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add calculator example binary using DeepSeek tools
- document the new example in README
- clarify that calculator is optional and not part of the main crypto gainer service

## Testing
- `cargo fmt --all` *(fails: `rustfmt` not installed)*
- `cargo check` *(fails: could not fetch crates)*
- `cargo test --no-run` *(fails: could not fetch crates)*