### PR TITLE
Update Shuttle runtime version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-shuttle-axum = "0.35"
-shuttle-runtime = "0.35"
+shuttle-axum = "0.53.0"
+shuttle-runtime = "0.53.0"
 tokio = { version = "1.37", features = ["full"] }
 tokio-tungstenite = "0.21"
 tungstenite = "0.21"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ crypto gainer service:
 - `sentiment` showcases running several extraction agents in parallel.
 - `calculator` illustrates using DeepSeek tools for simple arithmetic.
 
+When issuing multiple DeepSeek requests, the examples leverage
+`futures::stream::iter` with `buffer_unordered` to run calls concurrently.
+Successful responses are cached so repeated runs avoid unnecessary network
+traffic.
+
 ## Canonical Cargo Commands
 
 The helper scripts above are optional. You can perform the same tasks using


### PR DESCRIPTION
## Summary
- bump `shuttle-runtime`/`shuttle-axum` to v0.53.0
- document caching and parallelism for DeepSeek calls

## Testing
- `cargo fmt --all` *(fails: 'cargo-fmt' not installed)*
- `cargo check` *(fails: failed to get `anyhow` as a dependency)*
- `cargo test --offline` *(fails: no matching package named `anyhow` found)*