### PR TITLE
Fix axum version mismatch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,7 @@ mod ws;
 
 use std::sync::Arc;
 
-use axum::{extract::ws::Message, routing::get, Extension, Router};
-use shuttle_axum::ShuttleAxum;
+use shuttle_axum::{axum::{extract::ws::Message, routing::get, Extension, Router}, ShuttleAxum};
 use tokio::sync::{watch, Mutex};
 use tower_http::services::ServeDir;
 


### PR DESCRIPTION
## Summary
- use axum re-exported by shuttle-axum in `main.rs`

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' not installed)*
- `cargo check --locked` *(fails to download index)*
- `cargo test --locked` *(fails to download index)*