### PR TITLE
Fix axum mismatches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = { version = "0.6", features = ["ws"] }
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, time::Duration};
 
-use axum::extract::ws::Message;
+use shuttle_axum::axum::extract::ws::Message;
 use chrono::{DateTime, Utc};
 use futures::StreamExt;
 use serde::Serialize;

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use axum::{
+use shuttle_axum::axum::{
     extract::{
         ws::{Message, WebSocket},
         WebSocketUpgrade,


### PR DESCRIPTION
## Summary
- remove direct `axum` dependency
- import Axum types through `shuttle_axum`

## Testing
- `cargo fmt` *(fails: rustfmt component missing)*
- `cargo check` *(fails: could not fetch crates)*
- `cargo test` *(fails: could not fetch crates)*