### PR TITLE
Fix imports for shuttle-axum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-shuttle-axum = "0.53.0"
-shuttle-runtime = "0.53.0"
+shuttle-axum = "0.35.2"
+shuttle-runtime = "0.35.2"
 tokio = { version = "1.37", features = ["full"] }
 tokio-tungstenite = "0.21"
 tungstenite = "0.21"

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, time::Duration};
 
-use axum::extract::ws::Message;
+use shuttle_axum::axum::extract::ws::Message;
 use chrono::{DateTime, Utc};
 use futures::StreamExt;
 use serde::Serialize;

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use axum::{
+use shuttle_axum::axum::{
     extract::{
         ws::{Message, WebSocket},
         WebSocketUpgrade,


### PR DESCRIPTION
## Summary
- use `shuttle_axum`'s re-exported `axum` types everywhere
- align `shuttle-axum` and `shuttle-runtime` versions with Cargo.lock

## Testing
- `cargo check` *(fails: failed to get `anyhow`)*
- `cargo test` *(fails: failed to get `anyhow`)*