### PR TITLE
Fix double tracing subscriber init

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,13 @@ use ws::{websocket_handler, State};
 
 #[shuttle_runtime::main]
 async fn main() -> ShuttleAxum {
-    tracing_subscriber::fmt()
+    // Initialize tracing only if a global subscriber hasn't already been set.
+    // Shuttle's runtime installs one when running locally, so we use
+    // `try_init` to avoid panicking with `SetGlobalDefaultError`.
+    let _ = tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
         .with_target(false)
-        .init();
+        .try_init();
 
     let (tx, rx) = watch::channel(Message::Text("{}".into()));
     tokio::spawn(spawn_binance_feed(tx));


### PR DESCRIPTION
## Summary
- avoid panic by initializing tracing with `try_init`

## Testing
- `cargo fmt` *(fails: `cargo-fmt` is not installed)*
- `cargo check` *(fails: failed to download crates)*
- `cargo test --locked` *(fails: failed to download crates)*