### PR TITLE
Update README with UI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ For convenience, use the provided shell scripts to run or deploy via Shuttle.
 ./run.sh
 ```
 Runs the service locally using `shuttle run` and the `Secrets.toml` file in the repository root.
+After the server starts, open `http://localhost:8000/` in your browser to access the web UI served from `static/index.html`.
 
 ```bash
 ./deploy.sh


### PR DESCRIPTION
## Summary
- document how to open the UI when running `./run.sh`

## Testing
- `cargo fmt --all` *(fails: rustfmt component missing)*
- `cargo check` *(fails: network unavailable for crates.io)*
- `cargo test -- --test-threads=1` *(fails: network unavailable for crates.io)*