### PR TITLE
Fix WS TLS error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ shuttle-axum = { version = "0.54.0", default-features = false, features = ["axum
 shuttle-runtime = "0.54.0"
 tower-http = { version = "0.5.0", features = ["fs"] }
 tokio = { version = "1.37", features = ["full"] }
-tokio-tungstenite = "0.21"
-tungstenite = "0.21"
+tokio-tungstenite = { version = "0.21", features = ["rustls-tls-webpki-roots"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The Binance stream used here is public, so **no API keys are required**. The app
    cargo run --release
    ```
    By default the server listens on `127.0.0.1:8000`. It exposes a WebSocket endpoint at `/websocket` and serves a basic HTML client at the root path.
+   If you see a `TlsFeatureNotEnabled` error, ensure the `rustls-tls-webpki-roots` feature for `tokio-tungstenite` is enabled in `Cargo.toml`.
 3. Visit `http://localhost:8000/` in your browser to see the live feed. Each message shows a coin symbol and volume information whenever the 24h price increase exceeds 5% and the quote volume is above $1M.
 
 ### Running with Shuttle


### PR DESCRIPTION
## Summary
- enable Rustls TLS feature for tokio-tungstenite
- document TLS error in README

## Testing
- `cargo fmt` *(fails: rustfmt not installed)*
- `cargo check` *(fails: could not connect to crates.io)*
- `cargo test --quiet` *(fails: could not connect to crates.io)*