### PR TITLE
Auto open local UI on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ For convenience, use the provided shell scripts to run or deploy via Shuttle.
 ```bash
 ./run.sh
 ```
-Runs the service locally using `shuttle run` and the `Secrets.toml` file in the repository root.
-After the server starts, open `http://localhost:8000/` in your browser to access the web UI served from `static/index.html`.
+Runs the service locally using `shuttle run` and the `Secrets.toml` file in the repository root. The script automatically opens `http://localhost:8000/` in your default browser, loading the web UI served from `static/index.html`.
 
 ```bash
 ./deploy.sh

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,17 @@
 #!/usr/bin/env bash
 clear
-RUST_LOG=debug shuttle run --secrets Secrets.toml
+RUST_LOG=debug shuttle run --secrets Secrets.toml &
+PID=$!
+# Wait briefly for the server to start listening
+sleep 2
+
+URL="http://localhost:8000/"
+if command -v xdg-open >/dev/null; then
+    xdg-open "$URL" >/dev/null 2>&1 &
+elif command -v open >/dev/null; then
+    open "$URL" >/dev/null 2>&1 &
+else
+    echo "Server running at $URL"
+fi
+
+wait $PID

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -2,7 +2,7 @@ use std::{error::Error, time::Duration};
 
 use shuttle_axum::axum::extract::ws::Message;
 use chrono::{DateTime, Utc};
-use futures::StreamExt;
+use futures::{StreamExt, SinkExt};
 use serde::Serialize;
 use tokio::sync::watch;
 use tokio_tungstenite::{connect_async, tungstenite};


### PR DESCRIPTION
## Summary
- launch the browser automatically from `run.sh`
- document auto-opening behavior in README
- fix compile error in websocket stream

## Testing
- `cargo fmt --all` *(fails: 'cargo-fmt' not installed)*
- `cargo check` *(fails: could not download crates)*
- `cargo test` *(fails: could not download crates)*