### PR TITLE
Enable file-based logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tokio-tungstenite = { version = "0.21", features = ["rustls-tls-webpki-roots"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
+tracing-appender = "0.2"
 rig-core = "0.12.0"
 schemars = "0.8"
 anyhow = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ mod stream;
 mod ws;
 
 use std::sync::Arc;
+use tracing_appender::{non_blocking, rolling};
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 use shuttle_axum::{axum::{extract::ws::Message, routing::get, Extension, Router}, ShuttleAxum};
 use tokio::sync::{watch, Mutex};
@@ -15,9 +17,18 @@ async fn main() -> ShuttleAxum {
     // Initialize tracing only if a global subscriber hasn't already been set.
     // Shuttle's runtime installs one when running locally, so we use
     // `try_init` to avoid panicking with `SetGlobalDefaultError`.
-    let _ = tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
-        .with_target(false)
+    // Log to both stdout and a rolling log file under `logs/server.log`.
+    let file_appender = tracing_appender::rolling::daily("logs", "server.log");
+    let (file_writer, guard) = tracing_appender::non_blocking(file_appender);
+
+    // Prevent the writer from being dropped prematurely.
+    Box::leak(Box::new(guard));
+
+    let registry = tracing_subscriber::registry()
+        .with(fmt::layer().with_target(false).with_writer(std::io::stdout))
+        .with(fmt::layer().with_target(false).with_writer(file_writer));
+
+    let _ = registry
         .try_init();
 
     let (tx, rx) = watch::channel(Message::Text("{}".into()));


### PR DESCRIPTION
## Summary
- configure tracing to output to stdout and a rolling `logs/server.log`
- add `tracing-appender` dependency

## Testing
- `cargo fmt --all` *(fails: `cargo-fmt` not installed)*
- `cargo check` *(fails: could not download crates)*
- `cargo test` *(fails: could not download crates)*