### PR TITLE
Fix import path for VERSION constant

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use tower_http::services::ServeDir;
 
 use stream::spawn_binance_feed;
 use ws::{websocket_handler, State};
-use crate::VERSION;
+use crypto_scanner_agent::VERSION;
 
 #[derive(Serialize)]
 struct VersionResponse<'a> {


### PR DESCRIPTION
## Summary
- fix unresolved `VERSION` import in `main.rs`

## Testing
- `cargo fmt` *(fails: rustfmt component missing)*
- `cargo check` *(fails: failed to download crates.io index)*
- `cargo test` *(fails: failed to download crates.io index)*