### PR TITLE
Fix run script waiting for server

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,25 @@
 #!/usr/bin/env bash
+set -e
 clear
 RUST_LOG=debug shuttle run --secrets Secrets.toml &
 PID=$!
-# Wait briefly for the server to start listening
-sleep 2
 
 URL="http://localhost:8000/"
+# Wait until the server is reachable
+for _ in {1..30}; do
+    if nc -z localhost 8000; then
+        break
+    fi
+    sleep 1
+done
+
+if ! nc -z localhost 8000; then
+    echo "Server failed to start at $URL"
+    kill $PID
+    wait $PID
+    exit 1
+fi
+
 if command -v xdg-open >/dev/null; then
     xdg-open "$URL" >/dev/null 2>&1 &
 elif command -v open >/dev/null; then


### PR DESCRIPTION
## Summary
- wait for the local service to accept connections before opening the URL

## Testing
- `cargo check` *(fails: could not connect to crates.io)*
- `cargo test` *(fails: could not connect to crates.io)*