### PR TITLE
Fix WebSocket protocol for HTTP

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -41,7 +41,8 @@ body {
 <ul id="feed"></ul>
 <script>
 const ul = document.getElementById("feed");
-const ws = new WebSocket("wss://" + location.host + "/websocket");
+const wsScheme = location.protocol === "https:" ? "wss://" : "ws://";
+const ws = new WebSocket(wsScheme + location.host + "/websocket");
 ws.onmessage = ev => {
   const s = JSON.parse(ev.data);
   const li = document.createElement("li");


### PR DESCRIPTION
## Summary
- use `ws://` when the page is served over HTTP

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' not installed)*
- `cargo check` *(fails: could not fetch crates.io index)*
- `cargo test` *(fails: could not fetch crates.io index)*
