### PR TITLE
Improve log handling on local start

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ For convenience, use the provided shell scripts to run or deploy via Shuttle.
 ```bash
 ./run.sh
 ```
-Runs the service locally using `shuttle run` and the `Secrets.toml` file in the repository root. The script automatically opens `http://localhost:8000/` in your default browser, loading the web UI served from `static/index.html`.
+Runs the service locally using `shuttle run` and the `Secrets.toml` file in the repository root. The script automatically opens `http://localhost:8000/` in your default browser, loading the web UI served from `static/index.html`. It also clears any existing log files under `logs/` before starting the server so each run begins with fresh logs.
 
 ```bash
 ./deploy.sh

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 clear
+LOG_DIR="logs"
+# Remove existing log files so each run starts fresh
+rm -rf "$LOG_DIR"
+
 RUST_LOG=debug shuttle run --secrets Secrets.toml &
 PID=$!
 # Wait briefly for the server to start listening


### PR DESCRIPTION
## Summary
- delete old logs at the start of `run.sh`
- document that behaviour in README

## Testing
- `cargo check` *(fails: failed to download crates index)*
- `cargo test` *(fails: failed to download crates index)*