### PR TITLE
Add optional Nautilus Trader example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,10 @@ anyhow = "1"
 thiserror = "1"
 num_cpus = "1"
 
+# Optional integration with Nautilus Trader. This dependency is only
+# built when the `nautilus` feature is enabled.
+nautilus-trader = { version = "0.0.1", optional = true }
+
+[features]
+nautilus = ["nautilus-trader"]
+

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ crypto gainer service:
 
 - `sentiment` showcases running several extraction agents in parallel.
 - `calculator` illustrates using DeepSeek tools for simple arithmetic.
+- `nautilus_example` demonstrates a placeholder integration with
+  [Nautilus Trader](https://github.com/nautilus-trader/nautilus-trader). Enable
+  the `nautilus` feature to compile this binary.
 
 When issuing multiple DeepSeek requests, the examples leverage
 `futures::stream::iter` with `buffer_unordered` to run calls concurrently.
@@ -142,6 +145,9 @@ cargo run --bin sentiment --release
 
 # run the calculator example (optional)
 cargo run --bin calculator --release
+
+# run the Nautilus Trader example (optional)
+cargo run --bin nautilus_example --features nautilus --release
 
 # deploy with Shuttle
 cargo shuttle deploy -- --secrets backend/Secrets.toml

--- a/src/bin/nautilus_example.rs
+++ b/src/bin/nautilus_example.rs
@@ -1,0 +1,14 @@
+#[cfg(feature = "nautilus")]
+use nautilus_trader as nt;
+
+#[cfg(feature = "nautilus")]
+fn main() {
+    // Placeholder demonstrating where Nautilus Trader logic would run.
+    println!("Nautilus Trader integration enabled: {}", nt::VERSION);
+}
+
+#[cfg(not(feature = "nautilus"))]
+fn main() {
+    println!("Nautilus Trader feature not enabled.\n\
+             Rebuild with `--features nautilus` to run this example.");
+}


### PR DESCRIPTION
## Summary
- add optional `nautilus-trader` dependency and feature
- provide `nautilus_example` binary showcasing where Nautilus Trader would run
- document new example in the README with instructions

## Testing
- `cargo fmt` *(fails: rustfmt not installed)*
- `cargo check` *(fails: could not fetch crates.io index)*
- `cargo test` *(fails: could not fetch crates.io index)*