### PR TITLE
Support OWNER secret for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ sequenceDiagram
 
 The Raydium stream used here is public, so **no API keys are required**. The application works out of the box without further configuration.
 
+### Secrets
+
+Some binaries read configuration from environment variables supplied via Shuttle
+secrets. To use the `raydium_cli` helper without passing a wallet address each
+time, add an `OWNER` entry to your `Secrets.toml`:
+
+```toml
+OWNER = "YOUR_SOLANA_ADDRESS"
+```
+
+When present, the `balances` command will default to this value if no owner is
+specified on the command line.
+
 ## Running the Server
 
 1. Clone this repository and change into its directory:

--- a/Secrets.toml.example
+++ b/Secrets.toml.example
@@ -1,0 +1,3 @@
+# Example secrets file for shuttle
+OWNER = "YOUR_SOLANA_ADDRESS"
+# DEEPSEEK_API_KEY = "your-api-key-here"


### PR DESCRIPTION
## Summary
- allow `raydium_cli balances` to read the wallet owner from the `OWNER` env var
- document `OWNER` in README
- provide a `Secrets.toml.example` showing how to store secrets

## Testing
- `cargo fmt --all` *(fails: 'cargo-fmt' not installed)*
- `cargo check` *(fails: failed to download crates)*
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6843fd1cb66c832fa10ff408ad170bc9