### PR TITLE
Fix GitHub Action setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Rust
-        uses: actions/setup-rust@v1
+        uses: rust-lang/setup-rust@v1
         with:
           rust-version: stable
       - name: Check formatting


### PR DESCRIPTION
## Summary
- update CI to use `rust-lang/setup-rust@v1`

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' is not installed)*
- `cargo check` *(fails: failed to download `anyhow` crate)*
- `cargo test` *(fails: failed to download `anyhow` crate)*

------
https://chatgpt.com/codex/tasks/task_e_68441fc04798832faaee90871e950744