### PR TITLE
Fix GitHub Actions for Rust setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Rust
-        uses: rust-lang/setup-rust@v1
+      - name: Set up Rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: stable
+          toolchain: stable
+          profile: minimal
+          override: true
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Build


### PR DESCRIPTION
## Summary
- use `actions-rs/toolchain` instead of missing `rust-lang/setup-rust`

## Testing
- `cargo fmt --all` *(fails: rustfmt missing)*
- `cargo check --all` *(fails: cannot download dependencies)*
- `cargo test --all --verbose` *(fails: cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684421b7f134832fbdce7c353ce45427