### PR TITLE
Add DeepSeek token checker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ crypto gainer service:
 
 - `sentiment` showcases running several extraction agents in parallel.
 - `calculator` illustrates using DeepSeek tools for simple arithmetic.
+- `token_checker` verifies cryptocurrency symbols with a DeepSeek agent.
 - `nautilus_example` demonstrates a placeholder integration with
   [Nautilus Trader](https://github.com/nautilus-trader/nautilus-trader). Enable
   the `nautilus` feature to compile this binary.
@@ -158,6 +159,9 @@ cargo run --bin sentiment --release
 
 # run the calculator example (optional)
 cargo run --bin calculator --release
+
+# run the token checker example (optional)
+cargo run --bin token_checker -- BTC ETH
 
 # run the Nautilus Trader example (optional)
 cargo run --bin nautilus_example --features nautilus --release

--- a/src/bin/token_checker.rs
+++ b/src/bin/token_checker.rs
@@ -1,0 +1,53 @@
+use rig::providers::deepseek::{self, Client};
+use futures::{stream, StreamExt};
+use anyhow::Result;
+use std::env;
+
+/// Response structure describing token status.
+#[derive(serde::Deserialize, serde::Serialize)]
+struct TokenReview {
+    /// Short comment about the token.
+    comment: String,
+}
+
+/// Check a single token symbol using a DeepSeek agent.
+async fn check_token(client: &Client, token: &str) -> Result<String> {
+    let agent = client
+        .extractor::<TokenReview>("gpt-4")
+        .preamble(
+            "You are a cryptocurrency expert. For the provided token symbol, \n             state whether it appears legitimate or suspicious in one short sentence.",
+        )
+        .build();
+
+    let prompt = format!("Token: {token}");
+    let review = agent.extract(&prompt).await?;
+    Ok(review.comment)
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt().with_target(false).init();
+
+    let client = Client::from_env();
+    let tokens: Vec<String> = env::args().skip(1).collect();
+    if tokens.is_empty() {
+        eprintln!("usage: token_checker SYMBOL [SYMBOL...]" );
+        std::process::exit(1);
+    }
+
+    let results = stream::iter(tokens.iter())
+        .map(|t| check_token(&client, t))
+        .buffer_unordered(8)
+        .collect::<Vec<_>>()
+        .await;
+
+    for (token, res) in tokens.iter().zip(results) {
+        match res {
+            Ok(comment) => println!("{token}: {comment}"),
+            Err(e) => eprintln!("{token}: error - {e}"),
+        }
+    }
+
+    Ok(())
+}
+


### PR DESCRIPTION
## Summary
- add `token_checker` binary demonstrating a DeepSeek rig-core agent for verifying tokens
- document the new example in README

## Testing
- `cargo fmt --all` *(fails: 'cargo-fmt' not installed)*
- `cargo check` *(fails: failed to download crates)*
- `cargo test --workspace` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684422f47a34832f9fdf887d6f731b73