### PR TITLE
Add rstest tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ nautilus-trader = { version = "0.0.1", optional = true }
 [features]
 nautilus = ["nautilus-trader"]
 
+[dev-dependencies]
+rstest = "0.18"
+

--- a/tests/parallel_rstest.rs
+++ b/tests/parallel_rstest.rs
@@ -1,0 +1,32 @@
+use futures::{stream, StreamExt};
+use std::time::{Duration, Instant};
+use rstest::rstest;
+
+async fn run_tasks(delays: Vec<u64>, concurrency: usize) -> Vec<u64> {
+    stream::iter(delays)
+        .map(|d| async move {
+            tokio::time::sleep(Duration::from_millis(d)).await;
+            d
+        })
+        .buffer_unordered(concurrency)
+        .collect::<Vec<_>>()
+        .await
+}
+
+#[rstest(concurrency, is_parallel,
+    case(3, true),
+    case(1, false)
+)]
+#[tokio::test]
+async fn parallelism_behavior(concurrency: usize, is_parallel: bool) {
+    let delays = vec![100, 100, 100];
+    let start = Instant::now();
+    let result = run_tasks(delays.clone(), concurrency).await;
+    let elapsed = start.elapsed();
+    assert_eq!(result.len(), delays.len());
+    if is_parallel {
+        assert!(elapsed < Duration::from_millis(200));
+    } else {
+        assert!(elapsed >= Duration::from_millis(300));
+    }
+}


### PR DESCRIPTION
## Summary
- add `rstest` as a dev dependency
- create parameterised async tests with `rstest`

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' not installed)*
- `cargo check` *(fails to fetch index due to network restrictions)*
- `cargo test -- --nocapture` *(fails to fetch index due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6844336aafb4832fb9b24ee7e1076199