### PR TITLE
Add make target for Raydium balances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SENTIMENT = cargo run --bin sentiment --release
 CALCULATOR = cargo run --bin calculator --release
 TOKEN_CHECKER = cargo run --bin token_checker -- BTC ETH
 NAUTILUS = cargo run --bin nautilus_example --features nautilus --release
+RAY_BALANCES = cargo run --bin raydium_cli --release -- balances $(OWNER)
 SHUTTLE_RUN = shuttle run --secrets Secrets.toml
 DEPLOY = shuttle deploy --secrets backend/Secrets.toml
 FMT = cargo fmt --all
@@ -10,7 +11,7 @@ LINT = cargo clippy --all-targets --all-features -- -D warnings
 CHECK = cargo check
 TEST = cargo test
 
-.PHONY: run sentiment calculator token-checker nautilus shuttle-run deploy fmt lint check test
+.PHONY: run sentiment calculator token-checker raydium-balances nautilus shuttle-run deploy fmt lint check test
 
 run:
 $(RUN_RELEASE)
@@ -23,6 +24,9 @@ $(CALCULATOR)
 
 token-checker:
 $(TOKEN_CHECKER)
+
+raydium-balances:
+$(RAY_BALANCES)
 
 nautilus:
 $(NAUTILUS)


### PR DESCRIPTION
## Summary
- allow running balances via Makefile

## Testing
- `cargo fmt` *(fails: rustfmt not installed)*
- `cargo check --locked` *(fails: failed to download crates)*
- `cargo test --locked` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684458d4fd94832fa7c27de0924481ea