### PR TITLE
Add make target for Raydium top coins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CALCULATOR = cargo run --bin calculator --release
 TOKEN_CHECKER = cargo run --bin token_checker -- BTC ETH
 NAUTILUS = cargo run --bin nautilus_example --features nautilus --release
 RAY_BALANCES = cargo run --bin raydium_cli --release -- balances $(OWNER)
+RAY_TOP_COINS = cargo run --bin raydium_top_coins --release
 SHUTTLE_RUN = shuttle run --secrets Secrets.toml
 DEPLOY = shuttle deploy --secrets backend/Secrets.toml
 FMT = cargo fmt --all
@@ -11,7 +12,7 @@ LINT = cargo clippy --all-targets --all-features -- -D warnings
 CHECK = cargo check
 TEST = cargo test
 
-.PHONY: run sentiment calculator token-checker raydium-balances nautilus shuttle-run deploy fmt lint check test
+.PHONY: run sentiment calculator token-checker raydium-balances raydium-top-coins nautilus shuttle-run deploy fmt lint check test
 
 run:
 $(RUN_RELEASE)
@@ -27,6 +28,9 @@ $(TOKEN_CHECKER)
 
 raydium-balances:
 $(RAY_BALANCES)
+
+raydium-top-coins:
+$(RAY_TOP_COINS)
 
 nautilus:
 $(NAUTILUS)


### PR DESCRIPTION
## Summary
- add `raydium-top-coins` make target to easily run the new example

## Testing
- `cargo fmt --all` *(fails: rustfmt not installed)*
- `cargo check` *(fails to fetch crates)*
- `cargo test` *(fails to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_6844680270ac832facc113ac54dc4633