### PR TITLE
Fix Makefile indentation for commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,38 +14,38 @@ TEST = cargo test
 .PHONY: run sentiment calculator token-checker raydium-balances nautilus shuttle-run deploy fmt lint check test
 
 run:
-$(RUN_RELEASE)
+	$(RUN_RELEASE)
 
 sentiment:
-$(SENTIMENT)
+	$(SENTIMENT)
 
 calculator:
-$(CALCULATOR)
+	$(CALCULATOR)
 
 token-checker:
-$(TOKEN_CHECKER)
+	$(TOKEN_CHECKER)
 
 raydium-balances:
-$(RAY_BALANCES)
+	$(RAY_BALANCES)
 
 nautilus:
-$(NAUTILUS)
+	$(NAUTILUS)
 
 shuttle-run:
-$(SHUTTLE_RUN)
+	$(SHUTTLE_RUN)
 
 deploy:
-$(DEPLOY)
+	$(DEPLOY)
 
 fmt:
-$(FMT)
+	$(FMT)
 
 lint:
-$(LINT)
+	$(LINT)
 
 check:
-$(CHECK)
+	$(CHECK)
 
 test:
-$(TEST)
+	$(TEST)
 


### PR DESCRIPTION
## Summary
- fix indentation in `Makefile` so make recipes execute

## Testing
- `make raydium-balances` *(fails to download crates due to network restrictions)*
- `cargo fmt --all` *(fails: rustfmt component missing)*
- `cargo check` *(fails to download crates)*
- `cargo test` *(fails to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6844683a9428832f8d8e02a067d51e15