### PR TITLE
Fix doc comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub mod util {
     }
 }
 
-/// The version of the `crypto-scanner-agent` crate. This is populated at
+/// The version of the `crypto-scanner-agent` library. This is populated at
 /// compile time using the `CARGO_PKG_VERSION` environment variable.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 


### PR DESCRIPTION
## Summary
- update comments to refer to the library instead of the crate

## Testing
- `cargo check` *(fails: failed to download crates)*
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68446f367210832faccf374bdf0079da